### PR TITLE
Enhance matchup timeline visualization

### DIFF
--- a/web/matchup-timeline.html
+++ b/web/matchup-timeline.html
@@ -1,0 +1,691 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>High-Impact Matchup Timeline</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #050816;
+      --panel: rgba(12, 18, 36, 0.82);
+      --panel-solid: #11182f;
+      --ink: #f8fafc;
+      --muted: #a0abc0;
+      --accent: #38bdf8;
+      --border: rgba(56, 189, 248, 0.22);
+      --gold: #facc15;
+      --red: #f87171;
+      --emerald: #34d399;
+      --indigo: #818cf8;
+      --slate: #1e293b;
+      font-family: "Inter", "Segoe UI", sans-serif;
+    }
+    *, *::before, *::after {
+      box-sizing: border-box;
+    }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background:
+        radial-gradient(circle at 12% 18%, rgba(56,189,248,0.16) 0, transparent 45%),
+        radial-gradient(circle at 82% 8%, rgba(129,140,248,0.18) 0, transparent 42%),
+        var(--bg);
+      color: var(--ink);
+      display: flex;
+      flex-direction: column;
+      gap: 32px;
+      padding-bottom: 48px;
+    }
+    header {
+      padding: clamp(24px, 8vw, 48px) clamp(20px, 10vw, 72px) 0;
+      text-align: center;
+    }
+    header h1 {
+      margin: 0;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      font-size: clamp(22px, 3.2vw, 32px);
+    }
+    header p {
+      margin: 12px auto 0;
+      max-width: 720px;
+      color: var(--muted);
+      line-height: 1.6;
+      font-size: clamp(14px, 1.8vw, 16px);
+    }
+    main {
+      width: min(1040px, 92vw);
+      margin: 0 auto;
+      background: var(--panel);
+      border: 1px solid rgba(148, 163, 184, 0.12);
+      border-radius: 26px;
+      padding: clamp(20px, 5vw, 42px) clamp(18px, 5vw, 44px);
+      box-shadow: 0 32px 84px rgba(2,6,23,0.48);
+      backdrop-filter: blur(18px);
+      display: flex;
+      flex-direction: column;
+      gap: clamp(20px, 4vw, 36px);
+    }
+    .path-summary {
+      display: grid;
+      gap: 18px;
+    }
+    .path-summary header {
+      text-align: left;
+      padding: 0;
+    }
+    .path-summary h2 {
+      font-size: 17px;
+      letter-spacing: 0.04em;
+      color: var(--accent);
+      margin: 0 0 6px;
+    }
+    .path-summary p {
+      margin: 0;
+      color: var(--muted);
+      font-size: 13px;
+      line-height: 1.6;
+    }
+    .programs {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+    .programs li {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 8px 14px;
+      background: rgba(56, 189, 248, 0.12);
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      font-size: 13px;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+    .programs li span {
+      font-weight: 600;
+      letter-spacing: 0.03em;
+      font-size: 12px;
+      color: var(--ink);
+    }
+    .programs li small {
+      font-size: 10px;
+      color: var(--muted);
+    }
+    .programs li.arrow {
+      background: transparent;
+      border: none;
+      padding: 0 2px;
+      color: rgba(148, 163, 184, 0.56);
+    }
+    .filters {
+      display: grid;
+      gap: 16px;
+      padding: 18px;
+      border-radius: 18px;
+      background: rgba(8, 14, 31, 0.64);
+      border: 1px solid rgba(148, 163, 184, 0.18);
+    }
+    .filters h3 {
+      margin: 0;
+      font-size: 14px;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      color: rgba(248, 250, 252, 0.86);
+    }
+    .filter-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+    .chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      border-radius: 999px;
+      border: 1px solid rgba(148, 163, 184, 0.36);
+      background: rgba(15, 23, 42, 0.48);
+      padding: 6px 14px;
+      font-size: 12px;
+      letter-spacing: 0.03em;
+      color: var(--muted);
+      cursor: pointer;
+      transition: all 0.2s ease;
+    }
+    .chip[data-active="true"] {
+      border-color: var(--accent);
+      color: var(--ink);
+      background: rgba(56,189,248,0.16);
+      box-shadow: 0 0 0 3px rgba(56,189,248,0.12);
+    }
+    .legend {
+      display: grid;
+      gap: 12px;
+      margin-top: 4px;
+      font-size: 12px;
+      color: var(--muted);
+    }
+    .legend-row {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .legend-swatch {
+      width: 14px;
+      height: 14px;
+      border-radius: 4px;
+      border: 1px solid rgba(255,255,255,0.18);
+    }
+    .timeline {
+      position: relative;
+      padding-left: clamp(26px, 6vw, 52px);
+      border-left: 2px dashed rgba(56, 189, 248, 0.28);
+      display: grid;
+      gap: 24px;
+    }
+    .timeline::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      pointer-events: none;
+    }
+    .timeline-item {
+      position: relative;
+      padding-left: clamp(12px, 2vw, 20px);
+    }
+    .timeline-item::before {
+      content: "";
+      position: absolute;
+      left: calc(-1 * clamp(29px, 7vw, 60px));
+      top: 6px;
+      width: 16px;
+      height: 16px;
+      border-radius: 50%;
+      background: var(--bg);
+      border: 3px solid var(--accent);
+      box-shadow: 0 0 0 6px rgba(56, 189, 248, 0.18);
+    }
+    .timeline-date {
+      margin: 0 0 14px;
+      font-weight: 600;
+      letter-spacing: 0.04em;
+      font-size: 15px;
+      display: inline-flex;
+      align-items: center;
+      gap: 12px;
+    }
+    .timeline-date span {
+      font-size: 11px;
+      text-transform: uppercase;
+      color: rgba(148, 163, 184, 0.72);
+    }
+    .matchup-card {
+      background: rgba(8, 14, 31, 0.74);
+      border-radius: 16px;
+      border: 1px solid rgba(148,163,184,0.18);
+      padding: 16px 18px;
+      display: grid;
+      gap: 12px;
+    }
+    .matchup-head {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      justify-content: space-between;
+      align-items: center;
+    }
+    .matchup-head strong {
+      font-size: 16px;
+      letter-spacing: 0.02em;
+    }
+    .segment-tag {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      font-size: 11px;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      padding: 4px 10px;
+      border-radius: 999px;
+      border: 1px solid rgba(255,255,255,0.16);
+      background: rgba(255,255,255,0.06);
+    }
+    .segment-tag span {
+      font-weight: 600;
+    }
+    .meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      font-size: 12px;
+      color: var(--muted);
+    }
+    .meta span strong {
+      color: var(--ink);
+      font-weight: 600;
+    }
+    details {
+      border-radius: 12px;
+      border: 1px solid rgba(148,163,184,0.16);
+      background: rgba(15, 23, 42, 0.66);
+      padding: 10px 12px;
+    }
+    details summary {
+      cursor: pointer;
+      list-style: none;
+      font-size: 13px;
+      color: var(--accent);
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+    }
+    details summary::before {
+      content: "➜";
+      font-size: 12px;
+      transition: transform 0.2s ease;
+      color: rgba(148, 163, 184, 0.72);
+    }
+    details[open] summary::before {
+      transform: rotate(90deg);
+    }
+    details summary::-webkit-details-marker {
+      display: none;
+    }
+    details ul {
+      margin: 10px 0 0;
+      padding-left: 20px;
+      font-size: 13px;
+      line-height: 1.6;
+    }
+    .empty-state {
+      text-align: center;
+      padding: 36px 18px;
+      border-radius: 18px;
+      border: 1px dashed rgba(148, 163, 184, 0.22);
+      background: rgba(8, 14, 31, 0.44);
+      color: var(--muted);
+      font-size: 14px;
+      line-height: 1.6;
+    }
+    footer {
+      text-align: center;
+      font-size: 12px;
+      color: rgba(148, 163, 184, 0.68);
+      padding: 0 clamp(20px, 10vw, 72px);
+      line-height: 1.6;
+    }
+    @media (max-width: 640px) {
+      .timeline {
+        padding-left: 24px;
+      }
+      .timeline-item::before {
+        left: -32px;
+      }
+      .matchup-head {
+        flex-direction: column;
+        align-items: flex-start;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>High-Impact Matchup Timeline</h1>
+    <p>
+      Explore the Alabama → Clemson connection by surfacing the matchups that carry the most leverage on
+      the path between the two programs for the rest of the 2025 season. Filter by leverage tier to focus
+      on the tipping-point moments that can swing the playoff picture.
+    </p>
+  </header>
+  <main>
+    <section class="path-summary" id="pathSummary"></section>
+    <section class="filters" id="filters"></section>
+    <section class="timeline" id="timeline"></section>
+  </main>
+  <footer>
+    Leverage scores approximate how strongly each matchup can alter the shortest-connection leverage
+    between Alabama and Clemson. Conference tags reflect the primary affiliations feeding each edge.
+  </footer>
+  <script>
+    const tierLabels = {
+      critical: 'Critical leverage',
+      high: 'High leverage',
+      notable: 'Notable leverage',
+      watch: 'Watchlist leverage',
+    };
+
+    const tierColor = {
+      critical: 'var(--red)',
+      high: 'var(--gold)',
+      notable: 'var(--indigo)',
+      watch: 'var(--emerald)',
+    };
+
+    const determineTier = (value) => {
+      if (value >= 1.25) return 'critical';
+      if (value >= 1.05) return 'high';
+      if (value >= 0.85) return 'notable';
+      return 'watch';
+    };
+
+    const formatDate = (iso) => {
+      const date = new Date(`${iso}T00:00:00Z`);
+      return date.toLocaleDateString(undefined, {
+        weekday: 'long',
+        month: 'long',
+        day: 'numeric',
+        year: 'numeric',
+      });
+    };
+
+    const pathContext = {
+      title: 'Shortest leverage chain',
+      description:
+        'A leveraged hop-by-hop view that passes from the SEC through Notre Dame into the ACC to reach Clemson.',
+      programs: [
+        { name: 'Alabama', conference: 'SEC' },
+        { name: 'Georgia', conference: 'SEC' },
+        { name: 'Notre Dame', conference: 'IND' },
+        { name: 'Florida State', conference: 'ACC' },
+        { name: 'Clemson', conference: 'ACC' },
+      ],
+      segments: [
+        {
+          id: 'alabama-georgia',
+          label: 'Alabama ↔ Georgia',
+          color: 'var(--gold)',
+          narrative: 'SEC title power pivot anchoring the start of the chain.',
+          games: [
+            {
+              date: '2025-11-30',
+              matchup: 'Alabama vs Georgia',
+              leverage: 1.227,
+              location: 'Bryant-Denny Stadium — Tuscaloosa, AL',
+              conferences: ['Alabama (SEC)', 'Georgia (SEC)'],
+              factors: [
+                'Direct rematch that can set the stage for Atlanta one week later.',
+                'Determines whether Alabama enters the title game with leverage advantage.',
+                'Outcome cascades toward the independent and ACC comparisons the committee will weigh.',
+              ],
+            },
+            {
+              date: '2025-12-06',
+              matchup: 'Georgia vs Alabama (SEC Championship)',
+              leverage: 1.334,
+              location: 'Mercedes-Benz Stadium — Atlanta, GA',
+              conferences: ['Georgia (SEC)', 'Alabama (SEC)'],
+              factors: [
+                'Highest leverage contest on the chain, likely deciding the conference champion.',
+                'Locks in the SEC edge that initiates the whole path toward Clemson.',
+                'Result defines how much downstream pressure rests on Notre Dame and the ACC title picture.',
+              ],
+            },
+          ],
+        },
+        {
+          id: 'georgia-notre-dame',
+          label: 'Georgia ↔ Notre Dame',
+          color: 'var(--accent)',
+          narrative: 'Cross-regional showdown tying SEC power to a national independent.',
+          games: [
+            {
+              date: '2025-09-14',
+              matchup: 'Notre Dame vs Georgia',
+              leverage: 1.225,
+              location: 'Notre Dame Stadium — South Bend, IN',
+              conferences: ['Notre Dame (IND)', 'Georgia (SEC)'],
+              factors: [
+                'Shapes how the committee compares SEC strength to independent resumes in November.',
+                'Gives Georgia a leverage bridge outside the SEC footprint.',
+                'Establishes Notre Dame’s downstream influence on the ACC segment.',
+              ],
+            },
+          ],
+        },
+        {
+          id: 'notre-dame-florida-state',
+          label: 'Notre Dame ↔ Florida State',
+          color: 'var(--indigo)',
+          narrative: 'Independent-to-ACC checkpoint that can reshuffle November leverage.',
+          games: [
+            {
+              date: '2025-11-09',
+              matchup: 'Florida State vs Notre Dame',
+              leverage: 1.115,
+              location: 'Doak Campbell Stadium — Tallahassee, FL',
+              conferences: ['Florida State (ACC)', 'Notre Dame (IND)'],
+              factors: [
+                'Late-season referendum on which résumé feeds the ACC champion résumé boost.',
+                'Winner claims the comparison anchor if Clemson drops a game.',
+                'Result feeds back into how the SEC results are contextualized nationally.',
+              ],
+            },
+          ],
+        },
+        {
+          id: 'florida-state-clemson',
+          label: 'Florida State ↔ Clemson',
+          color: 'var(--emerald)',
+          narrative: 'ACC showdown that completes the Alabama-to-Clemson loop.',
+          games: [
+            {
+              date: '2025-09-21',
+              matchup: 'Florida State vs Clemson',
+              leverage: 0.614,
+              location: 'Doak Campbell Stadium — Tallahassee, FL',
+              conferences: ['Florida State (ACC)', 'Clemson (ACC)'],
+              factors: [
+                'Winner seizes the inside track to the ACC title game and the final edge of the chain.',
+                'Outcome determines whether Notre Dame needs a clean sweep to stay relevant.',
+                'Provides Clemson leverage insurance before the November gauntlet.',
+              ],
+            },
+            {
+              date: '2025-12-05',
+              matchup: 'Projected ACC Championship (Clemson vs TBD)',
+              leverage: 0.872,
+              location: 'Bank of America Stadium — Charlotte, NC',
+              conferences: ['Clemson (ACC)', 'TBD (ACC)'],
+              factors: [
+                'Clemson’s performance here back-propagates leverage to Florida State should the Seminoles reach Charlotte.',
+                'Serves as the final validation node for the Alabama-to-Clemson path.',
+                'Leverage fluctuates with Florida State’s conference trajectory.',
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const flattenTimeline = (segments) =>
+      segments
+        .flatMap((segment) =>
+          segment.games.map((game) => ({
+            ...game,
+            segmentId: segment.id,
+            segmentLabel: segment.label,
+            color: segment.color,
+            narrative: segment.narrative,
+          })),
+        )
+        .sort((a, b) => new Date(a.date) - new Date(b.date));
+
+    const pathSummary = document.getElementById('pathSummary');
+    const filters = document.getElementById('filters');
+    const timeline = document.getElementById('timeline');
+
+    const renderSummary = () => {
+      const heading = document.createElement('header');
+      const title = document.createElement('h2');
+      title.textContent = pathContext.title;
+      const copy = document.createElement('p');
+      copy.textContent = pathContext.description;
+      heading.append(title, copy);
+
+      const list = document.createElement('ul');
+      list.className = 'programs';
+      pathContext.programs.forEach((program, index) => {
+        const item = document.createElement('li');
+        item.innerHTML = `<span>${program.name}</span><small>${program.conference}</small>`;
+        list.appendChild(item);
+        if (index < pathContext.programs.length - 1) {
+          const arrow = document.createElement('li');
+          arrow.className = 'arrow';
+          arrow.textContent = '→';
+          list.appendChild(arrow);
+        }
+      });
+
+      pathSummary.append(heading, list);
+    };
+
+    const renderFilters = (activeTier) => {
+      filters.innerHTML = '';
+
+      const tierHeading = document.createElement('h3');
+      tierHeading.textContent = 'Focus by leverage tier';
+      filters.appendChild(tierHeading);
+
+      const row = document.createElement('div');
+      row.className = 'filter-row';
+
+      const tiers = ['all', ...Object.keys(tierLabels)];
+      tiers.forEach((tierKey) => {
+        const button = document.createElement('button');
+        button.className = 'chip';
+        button.type = 'button';
+        button.dataset.tier = tierKey;
+        button.dataset.active = String(activeTier === tierKey);
+        if (tierKey === 'all') {
+          button.textContent = 'Show all';
+        } else {
+          button.innerHTML = `<span style="width:10px;height:10px;border-radius:50%;background:${tierColor[tierKey]};display:inline-block"></span>${tierLabels[tierKey]}`;
+        }
+        button.addEventListener('click', () => {
+          state.activeTier = tierKey;
+          renderFilters(state.activeTier);
+          renderTimeline();
+        });
+        row.appendChild(button);
+      });
+
+      filters.appendChild(row);
+
+      const legend = document.createElement('div');
+      legend.className = 'legend';
+      pathContext.segments.forEach((segment) => {
+        const item = document.createElement('div');
+        item.className = 'legend-row';
+        const swatch = document.createElement('span');
+        swatch.className = 'legend-swatch';
+        swatch.style.background = segment.color;
+        item.appendChild(swatch);
+        const text = document.createElement('span');
+        text.textContent = `${segment.label} — ${segment.narrative}`;
+        item.appendChild(text);
+        legend.appendChild(item);
+      });
+      filters.appendChild(legend);
+    };
+
+    const renderTimeline = () => {
+      timeline.innerHTML = '';
+      const games = flattenTimeline(pathContext.segments);
+      const filtered = games.filter((game) => {
+        if (state.activeTier === 'all') return true;
+        return determineTier(game.leverage) === state.activeTier;
+      });
+
+      if (!filtered.length) {
+        const empty = document.createElement('div');
+        empty.className = 'empty-state';
+        empty.textContent = 'No matchups hit that leverage band on this path. Try broadening the filter.';
+        timeline.appendChild(empty);
+        return;
+      }
+
+      const groups = filtered.reduce((acc, game) => {
+        acc[game.date] = acc[game.date] || [];
+        acc[game.date].push(game);
+        return acc;
+      }, {});
+
+      Object.entries(groups)
+        .sort((a, b) => new Date(a[0]) - new Date(b[0]))
+        .forEach(([date, gamesOnDate]) => {
+          const item = document.createElement('article');
+          item.className = 'timeline-item';
+
+          const dateLabel = document.createElement('h3');
+          dateLabel.className = 'timeline-date';
+          const tierSet = new Set(gamesOnDate.map((game) => tierLabels[determineTier(game.leverage)]));
+          const tierText = Array.from(tierSet).join(' • ');
+          dateLabel.innerHTML = `${formatDate(date)} <span>${tierText}</span>`;
+          item.appendChild(dateLabel);
+
+          gamesOnDate
+            .sort((a, b) => b.leverage - a.leverage)
+            .forEach((game) => {
+              const card = document.createElement('div');
+              card.className = 'matchup-card';
+              card.style.borderColor = `${game.color}33`;
+              card.style.boxShadow = `0 0 0 1px ${game.color}1f`;
+
+              const head = document.createElement('div');
+              head.className = 'matchup-head';
+              head.innerHTML = `<strong>${game.matchup}</strong>`;
+
+              const tag = document.createElement('span');
+              tag.className = 'segment-tag';
+              tag.style.borderColor = `${game.color}66`;
+              tag.style.background = `${game.color}1a`;
+              tag.innerHTML = `<span>${game.segmentLabel}</span>`;
+              head.appendChild(tag);
+              card.appendChild(head);
+
+              const meta = document.createElement('div');
+              meta.className = 'meta';
+              meta.innerHTML = `
+                <span>${game.location}</span>
+                <span>Leverage score: <strong>${game.leverage.toFixed(3)}</strong></span>
+                <span>Tier: <strong>${tierLabels[determineTier(game.leverage)]}</strong></span>
+                <span>Conferences: ${game.conferences.join(' vs ')}</span>
+              `;
+              card.appendChild(meta);
+
+              const details = document.createElement('details');
+              const summary = document.createElement('summary');
+              summary.textContent = 'Edge factors';
+              details.appendChild(summary);
+
+              const list = document.createElement('ul');
+              game.factors.forEach((factor) => {
+                const li = document.createElement('li');
+                li.textContent = factor;
+                list.appendChild(li);
+              });
+              details.appendChild(list);
+
+              card.appendChild(details);
+              item.appendChild(card);
+            });
+
+          timeline.appendChild(item);
+        });
+    };
+
+    const state = {
+      activeTier: 'all',
+    };
+
+    renderSummary();
+    renderFilters(state.activeTier);
+    renderTimeline();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- restyle the matchup timeline experience with a glassmorphism card layout and richer path summary context
- add leverage-tier filtering, segment legend, and timeline grouping to explore pivotal matchups along the Alabama→Clemson path
- expand the data model with segment metadata and projected championship context for downstream leverage analysis

## Testing
- not run (static webpage)


------
https://chatgpt.com/codex/tasks/task_e_68e3845b9298832f9ab27aab5ebf353a